### PR TITLE
docs: migrate license link to Lamplit Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Currencies => https://gist.github.com/manishtiwari25/d3984385b1cb200b98bcde69026
 
 ## License
 
-Licensed under the [MIT license](https://github.com/bitesinbyte/gist-automations/blob/main/LICENSE).
+Licensed under the [MIT license](https://github.com/lamplitlabs/gist-automations/blob/main/LICENSE).


### PR DESCRIPTION
## Summary
- update the README license URL from the former Bites In Byte organization to Lamplit Labs
- preserve the historical MIT copyright attribution and license terms

## Validation
- `dotnet build GistAutomation --configuration Release --nologo`
- `git diff --check`
- residual legacy-brand search across tracked files (only the historical LICENSE attribution remains)
- verified the updated license URL resolves